### PR TITLE
Add id field to Videos interface

### DIFF
--- a/src/Listeners/GetVideosFieldSchema.php
+++ b/src/Listeners/GetVideosFieldSchema.php
@@ -21,6 +21,7 @@ class GetVideosFieldSchema
         $schema = $event->schema;
 
         $object = $schema->createObjectType('Videos');
+        $object->addIntField('id');
         $object->addStringField('title');
         $object->addStringField('url');
         $embed = $object->addStringField('embed')


### PR DESCRIPTION
This pull request simply adds the [`id` property from the `Video` model](https://docs.dukt.net/videos/v2/video-model.html#id) as an integer field on the `Videos` interface.

Adding this field might help those directly using the Vimeo player SDK or some player component, like [vue-vimeo-player](https://www.npmjs.com/package/vue-vimeo-player).